### PR TITLE
Add _BSD_SOURCE define for C compilation to prevent crashes.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,7 +8,7 @@ mkdir -p _build
 pushd _build
 
 # set missing flags
-export CFLAGS="-D_POSIX_C_SOURCE=199309L -DM_PI=3.14159265358979323846 ${CFLAGS}"
+export CFLAGS="-D_POSIX_C_SOURCE=199309L -D_BSD_SOURCE -DM_PI=3.14159265358979323846 ${CFLAGS}"
 if  [[ "$(uname)" == "Darwin" ]]; then
 	# required for TCP_KEEPALIVE
 	export CFLAGS="-D_DARWIN_C_SOURCE ${CFLAGS}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
     - perl-shebang.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
_BSD_SOURCE enables prototypes for bsd functions, in particular strdup().

Without _BSD_SOURCE defined, the compiler emits a warning, then happily links to the function as if it returned an int.

strdup() returns a pointer, which gets truncated, then causes a crash.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
