### PR TITLE
Update all run_exports pins to pin to 'x'

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
 build:
   error_overdepending: true
   error_overlinking: true
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -53,7 +53,7 @@ outputs:
     script: install-base.sh
     build:
       run_exports:
-        - {{ pin_subpackage("gds-base", max_pin="x.x") }}
+        - {{ pin_subpackage("gds-base", max_pin="x") }}
     requirements:
       build:
         - {{ compiler('c') }}
@@ -104,7 +104,7 @@ outputs:
     script: install-framexmit.sh
     build:
       run_exports:
-        - {{ pin_subpackage("gds-framexmit", max_pin="x.x") }}
+        - {{ pin_subpackage("gds-framexmit", max_pin="x") }}
     requirements:
       build:
         - {{ compiler('c') }}
@@ -136,7 +136,7 @@ outputs:
     script: install-base-crtools.sh
     build:
       run_exports:
-        - {{ pin_subpackage("gds-base-crtools", max_pin="x.x") }}
+        - {{ pin_subpackage("gds-base-crtools", max_pin="x") }}
     requirements:
       build:
         - {{ compiler('cxx') }}
@@ -169,7 +169,7 @@ outputs:
     script: install-base-gdstrig.sh
     build:
       run_exports:
-        - {{ pin_subpackage("gds-base-gdstrig", max_pin="x.x") }}
+        - {{ pin_subpackage("gds-base-gdstrig", max_pin="x") }}
     requirements:
       build:
         - {{ compiler('cxx') }}
@@ -200,7 +200,7 @@ outputs:
         - libcxx  # [osx]
         - libstdcxx-ng  # [linux]
       run_exports:
-        - {{ pin_subpackage("gds-base-monitors", max_pin="x.x") }}
+        - {{ pin_subpackage("gds-base-monitors", max_pin="x") }}
     requirements:
       build:
         - {{ compiler('cxx') }}
@@ -269,7 +269,7 @@ outputs:
     script: install-services.sh
     build:
       run_exports:
-        - {{ pin_subpackage("gds-services", max_pin="x.x") }}
+        - {{ pin_subpackage("gds-services", max_pin="x") }}
     requirements:
       build:
         - {{ compiler('cxx') }}


### PR DESCRIPTION
This PR updates all `run_exports` pins (those things that enforce compatibility version pins from this package on its _dependents_) to just pin the major GDS version, now that the GDS project is using semantic package versioning to indicate library compatibility.

@emaros, please confirm (and merge).

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
